### PR TITLE
fix(node_modules/azure-scripty) - workound for bad cli output

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "azure-arm-resource": "^0.10.6",
     "azure-cli": "^0.9.10",
     "azure-common": "^0.9.16",
-    "azure-scripty": "^1.0.1",
+    "azure-scripty": "git+https://sedouard@github.com/sedouard/azure-scripty.git",
     "body-parser": "~1.13.2",
     "cookie-parser": "~1.3.5",
     "debug": "~2.2.0",


### PR DESCRIPTION
Azure CLI's --json output has bugs and sometimes doesn't output
pure json causing us to have syntax validation errors. In these
cases we'll just return the output
